### PR TITLE
Feature/ps 18070 device flow - return `verificationUrlComplete`

### DIFF
--- a/OAuth2.xcodeproj/project.pbxproj
+++ b/OAuth2.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		8793811929D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
 		8793811A29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
 		8793811B29D483EC00DC4EBC /* OAuth2DeviceGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */; };
+		87B3E07C29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */; };
 		CCCE40D6B4EAD9BF05C92ACE /* OAuth2CustomAuthorizer+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCE4C8DC3CB7713E59BC1EE /* OAuth2CustomAuthorizer+iOS.swift */; };
 		DD0CCBAD1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift */; };
 		EA9758181B222CEA007744B1 /* OAuth2PasswordGrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */; };
@@ -172,6 +173,7 @@
 		659854461C5B3BEA00237D39 /* OAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EC05DF1C9050CB00DE9186 /* OAuth2KeychainAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2KeychainAccount.swift; sourceTree = "<group>"; };
 		8793811829D483EC00DC4EBC /* OAuth2DeviceGrant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2DeviceGrant.swift; sourceTree = "<group>"; };
+		87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2DeviceGrantTests.swift; sourceTree = "<group>"; };
 		CCCE4C8DC3CB7713E59BC1EE /* OAuth2CustomAuthorizer+iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OAuth2CustomAuthorizer+iOS.swift"; sourceTree = "<group>"; };
 		DD0CCBAC1C4DC83A0044C4E3 /* OAuth2WebViewController+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OAuth2WebViewController+macOS.swift"; sourceTree = "<group>"; };
 		EA9758171B222CEA007744B1 /* OAuth2PasswordGrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuth2PasswordGrant.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -319,6 +321,7 @@
 			children = (
 				EE4EBD811D7FF38200E6A9CA /* OAuth2ClientCredentialsTests.swift */,
 				EE4EBD821D7FF38200E6A9CA /* OAuth2CodeGrantTests.swift */,
+				87B3E07B29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift */,
 				EE4EBD831D7FF38200E6A9CA /* OAuth2DynRegTests.swift */,
 				EE4EBD841D7FF38200E6A9CA /* OAuth2ImplicitGrantTests.swift */,
 				EE4EBD851D7FF38200E6A9CA /* OAuth2PasswordGrantTests.swift */,
@@ -777,6 +780,7 @@
 				EE4EBD891D7FF38200E6A9CA /* OAuth2ClientCredentialsTests.swift in Sources */,
 				EE4EBD8B1D7FF38200E6A9CA /* OAuth2DynRegTests.swift in Sources */,
 				EE4EBD8A1D7FF38200E6A9CA /* OAuth2CodeGrantTests.swift in Sources */,
+				87B3E07C29F6AF240075C4DC /* OAuth2DeviceGrantTests.swift in Sources */,
 				EEB9A9801D86CD4A0022EF66 /* OAuth2DataLoaderTests.swift in Sources */,
 				EE4EBD8C1D7FF38200E6A9CA /* OAuth2ImplicitGrantTests.swift in Sources */,
 				EE4EBD8E1D7FF38200E6A9CA /* OAuth2RefreshTokenTests.swift in Sources */,

--- a/Sources/Flows/OAuth2DeviceGrant.swift
+++ b/Sources/Flows/OAuth2DeviceGrant.swift
@@ -95,14 +95,14 @@ open class OAuth2DeviceGrant: OAuth2 {
 				return
 			}
 			
-			if (useNonTextualTransmission) {
-				guard let verificationUriComplete = result["verification_uri_complete"] as? String,
-					  let verificationUrlComplete = URL(string: verificationUriComplete) else {
-					return
-				}
-				
+			var verificationUrlComplete: URL?
+			if let verificationUriComplete = result["verification_uri_complete"] as? String {
+				verificationUrlComplete = URL(string: verificationUriComplete)
+			}
+			
+			if useNonTextualTransmission, let url = verificationUrlComplete {
 				do {
-					try self.authorizer.openAuthorizeURLInBrowser(verificationUrlComplete)
+					try self.authorizer.openAuthorizeURLInBrowser(url)
 				} catch let error {
 					completion(nil, error)
 				}
@@ -118,7 +118,7 @@ open class OAuth2DeviceGrant: OAuth2 {
 				}
 			}
 			
-			let deviceAuthorization = DeviceAuthorization(userCode: userCode, verificationUrl: verificationUrl, expiresIn: expiresIn)
+			let deviceAuthorization = DeviceAuthorization(userCode: userCode, verificationUrl: verificationUrl, verificationUrlComplete: verificationUrlComplete, expiresIn: expiresIn)
 			completion(deviceAuthorization, nil)
 		}
 	}
@@ -182,7 +182,8 @@ open class OAuth2DeviceGrant: OAuth2 {
 }
 
 public struct DeviceAuthorization {
-	let userCode: String
-	let verificationUrl: URL
-	let expiresIn: Int
+	public let userCode: String
+	public let verificationUrl: URL
+	public let verificationUrlComplete: URL?
+	public let expiresIn: Int
 }

--- a/Sources/Flows/OAuth2DeviceGrant.swift
+++ b/Sources/Flows/OAuth2DeviceGrant.swift
@@ -23,7 +23,7 @@ import Foundation
 import Base
 #endif
 
-/// https://www.rfc-editor.org/rfc/rfc8628
+/// https://www.ietf.org/rfc/rfc8628.html
 open class OAuth2DeviceGrant: OAuth2 {
 	override open class var grantType: String {
 		return "urn:ietf:params:oauth:grant-type:device_code"
@@ -32,9 +32,7 @@ open class OAuth2DeviceGrant: OAuth2 {
 	override open class var responseType: String? {
 		return ""
 	}
-	
-	// MARK: - Token request
-	
+		
 	open func deviceAccessTokenRequest(with deviceCode: String) throws -> OAuth2AuthRequest {
 		guard let clientId = clientConfig.clientId, !clientId.isEmpty else {
 			throw OAuth2Error.noClientId
@@ -77,7 +75,6 @@ open class OAuth2DeviceGrant: OAuth2 {
 		return params
 	}
 	
-	// custom
 	public func start(useNonTextualTransmission: Bool = false, completion: @escaping (DeviceAuthorization?, Error?) -> Void) {
 		authorizeDevice { result, error in
 			guard let result else {
@@ -111,7 +108,7 @@ open class OAuth2DeviceGrant: OAuth2 {
 				}
 			}
 			
-			let pollingInterval = result["interval"] as? TimeInterval ?? 5 // TODO: use Int instead?
+			let pollingInterval = result["interval"] as? TimeInterval ?? 5
 			self.getDeviceAccessToken(deviceCode: deviceCode, interval: pollingInterval) { params, error in
 				if let params {
 					self.didAuthorize(withParameters: params)
@@ -151,8 +148,6 @@ open class OAuth2DeviceGrant: OAuth2 {
 		do {
 			let post = try deviceAccessTokenRequest(with: deviceCode).asURLRequest(for: self)
 			logger?.debug("OAuth2", msg: "Obtaining access token for device with code \(deviceCode) from \(post.url!)")
-			
-			// TODO: check if not expired
 			
 			perform(request: post) { response in
 				do {


### PR DESCRIPTION
In order to be able to return the user back to the authorization window (browser), we need to access the `verificationUrlComplete` used with the non-textual transmission sub-flow. This PR also introduces a minor cleaning of comments.

https://sli-do.atlassian.net/browse/PS-18070?atlOrigin=eyJpIjoiNjA3NGNhNTFiNmE2NGZlMWFhMmE1NjZkYjExZTgzZGYiLCJwIjoiaiJ9