### PR TITLE
Define Swift source code coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,8 @@
+# Swift source code
+[*.swift]
+indent_style = tab
+indent_size = 4
+
 # GitHub Actions workflow files
 [*.yml]
 indent_style = space


### PR DESCRIPTION
Formalize the usage of `tabs` in Swift source code as that's the style used in the original files.