### PR TITLE
Fix syntax highlighting of conditional imports in Xcode

### DIFF
--- a/Sources/DataLoader/OAuth2DataLoader.swift
+++ b/Sources/DataLoader/OAuth2DataLoader.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Flows

--- a/Sources/DataLoader/OAuth2DataLoaderSessionTaskDelegate.swift
+++ b/Sources/DataLoader/OAuth2DataLoaderSessionTaskDelegate.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/DataLoader/OAuth2DataRequest.swift
+++ b/Sources/DataLoader/OAuth2DataRequest.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Flows

--- a/Sources/Flows/OAuth2.swift
+++ b/Sources/Flows/OAuth2.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
  import Base
  import Constants

--- a/Sources/Flows/OAuth2ClientCredentials.swift
+++ b/Sources/Flows/OAuth2ClientCredentials.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Constants

--- a/Sources/Flows/OAuth2CodeGrant.swift
+++ b/Sources/Flows/OAuth2CodeGrant.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Constants

--- a/Sources/Flows/OAuth2CodeGrantAzure.swift
+++ b/Sources/Flows/OAuth2CodeGrantAzure.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/Flows/OAuth2CodeGrantBasicAuth.swift
+++ b/Sources/Flows/OAuth2CodeGrantBasicAuth.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/Flows/OAuth2CodeGrantFacebook.swift
+++ b/Sources/Flows/OAuth2CodeGrantFacebook.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/Flows/OAuth2DeviceGrant.swift
+++ b/Sources/Flows/OAuth2DeviceGrant.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Constants

--- a/Sources/Flows/OAuth2DynReg.swift
+++ b/Sources/Flows/OAuth2DynReg.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/Flows/OAuth2ImplicitGrant.swift
+++ b/Sources/Flows/OAuth2ImplicitGrant.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 import Constants

--- a/Sources/Flows/OAuth2ImplicitGrantWithQueryParams.swift
+++ b/Sources/Flows/OAuth2ImplicitGrantWithQueryParams.swift
@@ -18,9 +18,8 @@
 //  limitations under the License.
 //
 
-
-
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/Flows/OAuth2PasswordGrant.swift
+++ b/Sources/Flows/OAuth2PasswordGrant.swift
@@ -19,9 +19,11 @@
 //
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
  import Base
  import Constants
+
  #if os(macOS)
   import macOS
  #elseif os(iOS) || os(visionOS)
@@ -29,6 +31,7 @@ import Foundation
  #elseif os(tvOS)
   import tvOS
  #endif
+
 #endif
 
 

--- a/Sources/iOS/OAuth2Authorizer+iOS.swift
+++ b/Sources/iOS/OAuth2Authorizer+iOS.swift
@@ -22,6 +22,7 @@
 import UIKit
 import SafariServices
 import AuthenticationServices
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
+++ b/Sources/iOS/OAuth2CustomAuthorizer+iOS.swift
@@ -20,6 +20,7 @@
 #if os(visionOS) || os(iOS)
 import Foundation
 import UIKit
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/iOS/OAuth2WebViewController+iOS.swift
+++ b/Sources/iOS/OAuth2WebViewController+iOS.swift
@@ -22,6 +22,7 @@
 
 import UIKit
 import WebKit
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/macOS/OAuth2Authorizer+macOS.swift
+++ b/Sources/macOS/OAuth2Authorizer+macOS.swift
@@ -23,6 +23,7 @@ import Cocoa
 #if !NO_MODULE_IMPORT
 import Base
 #endif
+
 #if canImport(AuthenticationServices)
 import AuthenticationServices
 #endif

--- a/Sources/macOS/OAuth2CustomAuthorizer+macOS.swift
+++ b/Sources/macOS/OAuth2CustomAuthorizer+macOS.swift
@@ -20,6 +20,7 @@
 #if os(macOS)
 
 import Cocoa
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/macOS/OAuth2WebViewController+macOS.swift
+++ b/Sources/macOS/OAuth2WebViewController+macOS.swift
@@ -21,6 +21,7 @@
 
 import Cocoa
 import WebKit
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/tvOS/OAuth2Authorizer+tvOS.swift
+++ b/Sources/tvOS/OAuth2Authorizer+tvOS.swift
@@ -20,6 +20,7 @@
 #if os(tvOS)
 
 import Foundation
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif

--- a/Sources/tvOS/OAuth2CustomAuthorizer+tvOS.swift
+++ b/Sources/tvOS/OAuth2CustomAuthorizer+tvOS.swift
@@ -21,6 +21,7 @@
 
 import Foundation
 import UIKit
+
 #if !NO_MODULE_IMPORT
 import Base
 #endif


### PR DESCRIPTION
When compiler directives are used to decorate import blocks and those directives are not separated from other imports by an empty line, Xcode behaves unexpectedly and does not highlight syntax correctly - it displays imports that should be ignored for the current configuration as active. Adding an empty line before each compiler directive resolves this issue.

<img width="269" alt="image" src="https://github.com/user-attachments/assets/30c94d40-22fe-495b-88be-168ad2e38092" />
<img width="225" alt="image" src="https://github.com/user-attachments/assets/844bd759-cdff-4a0d-b0f9-d3940e2d773a" />

<img width="347" alt="image" src="https://github.com/user-attachments/assets/98866ff8-2da2-4b9e-ae88-66031d150082" />
<img width="354" alt="image" src="https://github.com/user-attachments/assets/d4b18a3a-866a-4cfd-8a15-43f1bd29a080" />


