### PR TITLE
Mark `DeviceAuthorization` with `Sendable`

### DIFF
--- a/Sources/Flows/OAuth2DeviceGrant.swift
+++ b/Sources/Flows/OAuth2DeviceGrant.swift
@@ -179,7 +179,7 @@ fileprivate extension Task where Success == Never, Failure == Never {
 	}
 }
 
-public struct DeviceAuthorization {
+public struct DeviceAuthorization: Sendable {
 	public let userCode: String
 	public let verificationUrl: URL
 	public let verificationUrlComplete: URL?


### PR DESCRIPTION
I need `DeviceAuthorization` to be `Sendable` to resolve warning in SFM.

```
Non-sendable type 'DeviceAuthorization' returned by implicitly asynchronous call to global actor 'OAuth2Actor'-isolated function cannot cross actor boundary; this is an error in the Swift 6 language mode
```